### PR TITLE
Fix taxon autocomplete in occurrence editor returning no results

### DIFF
--- a/classes/RpcOccurrenceEditor.php
+++ b/classes/RpcOccurrenceEditor.php
@@ -191,7 +191,18 @@ class RpcOccurrenceEditor extends RpcBase{
 			$sql .= ') ';
 		}
 
-		$sql .= 'ORDER BY sciname';
+		$sql = 'SELECT DISTINCT t.tid, t.sciname, t.author, t.sourceidentifier, IF(ts.tid IS NULL OR ts.tid = ts.tidaccepted, "accepted", "synonym") AS taxonstatus FROM taxa t LEFT JOIN taxstatus ts ON t.tid = ts.tid AND ts.taxauthid = 1 WHERE t.sciname LIKE "' . $fullterm . '%" ';
+		if(count($strArr) > 1){
+			$sql .= 'OR (t.unitname1 LIKE "' . $strArr[0] . '%" AND t.unitname2 LIKE "' . $strArr[1] . '%" ';
+			if(!empty($strArr[2])){
+				$sql .= 'AND t.unitname3 LIKE "' . $strArr[2] . '%" ';
+			}
+			$sql .= ') ';
+		}
+		$sql .= 'ORDER BY t.sciname';
+
+		// If the search term has an infraspecific separator, use sciname LIKE directly
+		if(array_intersect($strArr, array("var.", "ssp.", "nothossp.", "f.", "×", "x", "†"))) $sql = 'SELECT DISTINCT t.tid, t.sciname, t.author, t.sourceidentifier, IF(ts.tid IS NULL OR ts.tid = ts.tidaccepted, "accepted", "synonym") AS taxonstatus FROM taxa t LEFT JOIN taxstatus ts ON t.tid = ts.tid AND ts.taxauthid = 1 WHERE t.sciname LIKE "'.$term.'%" ';
 
 		$rs = $this->conn->query($sql);
 		while ($r = $rs->fetch_object()){


### PR DESCRIPTION
## Summary

The taxon name autocomplete in the occurrence editor was broken — typing a taxon name returned no results.

## Root Cause

A conflict resolution in `RpcOccurrenceEditor.php` left undefined variables (`$str1`, `$str2`, `$str3`) in the SQL query. This caused the LIKE clause to evaluate as `LIKE ""`, which matched nothing.

## Fix

Rewrote `getSpeciesSuggest()` to correctly use `$fullterm` and `$strArr`. Also enhanced the SELECT to return `sourceIdentifier` and taxon status (accepted/synonym) alongside sciname and author, enabling richer autocomplete display.

## Files Changed

- **`classes/RpcOccurrenceEditor.php`** — fixed `getSpeciesSuggest()` SQL query

## Test Plan

- [ ] Go to the occurrence editor
- [ ] Start typing a taxon name in the scientific name field
- [ ] Verify autocomplete results appear with sciname, author, sourceIdentifier, and accepted/synonym status

🤖 Generated with [Claude Code](https://claude.com/claude-code)