### PR TITLE
Fix unitName1 NULL constraint error on strict MariaDB versions

### DIFF
--- a/classes/TaxonomyUpload.php
+++ b/classes/TaxonomyUpload.php
@@ -816,7 +816,7 @@ class TaxonomyUpload{
 			$this->outputMsg('Starting loop '.$loopCnt);
 			$this->outputMsg('Transferring taxa to taxon table... ',1);
 			$sql = 'INSERT INTO taxa(kingdomName, SciName, RankId, UnitInd1, UnitName1, UnitInd2, UnitName2, UnitInd3, UnitName3, cultivarEpithet, tradeName, Author, Source, sourceIdentifier, nomenclaturalStatus, Notes) '.
-				'SELECT DISTINCT "'.$this->kingdomName.'", SciName, RankId, UnitInd1, UnitName1, UnitInd2, UnitName2, UnitInd3, UnitName3, cultivarEpithet, tradeName, Author, Source, sourceIdentifier, nomenclaturalStatus, Notes '.
+				'SELECT DISTINCT "'.$this->kingdomName.'", SciName, RankId, UnitInd1, IFNULL(NULLIF(TRIM(UnitName1),""), TRIM(SciName)), UnitInd2, UnitName2, UnitInd3, UnitName3, cultivarEpithet, tradeName, Author, Source, sourceIdentifier, nomenclaturalStatus, Notes '.
 				'FROM uploadtaxa '.
 				'WHERE (tid IS NULL) AND (parenttid IS NOT NULL) AND (rankid IS NOT NULL) AND (ErrorStatus IS NULL) '.
 				'ORDER BY RankId ASC '.


### PR DESCRIPTION
On MariaDB 10.6 (and other strict versions), a NULL value in a NOT NULL column aborts the entire INSERT statement rather than skipping the row. A small number of uploadtaxa rows can have NULL unitName1 due to unresolvable parent taxonomy in the source data, causing the entire batch INSERT to fail and no taxa to be inserted.

Fix: use IFNULL(NULLIF(TRIM(UnitName1),""), TRIM(SciName)) so that rows with NULL or empty unitName1 fall back to the sciname value, allowing the INSERT to succeed for all valid rows.

This was not caught on local development running MariaDB 12.2 which handles NULL NOT NULL violations more leniently.